### PR TITLE
Fix "all" placeholders for name/area

### DIFF
--- a/sentences/en/fan_HassTurnOff.yaml
+++ b/sentences/en/fan_HassTurnOff.yaml
@@ -11,7 +11,6 @@ intents:
           - "deactivate [all] <area> [the] fan[s]"
         slots:
           domain: "fan"
-          name: "all"
         response: fans_area
 
       - sentences:
@@ -20,5 +19,3 @@ intents:
         response: "light_all"
         slots:
           domain: "fan"
-          area: "all"
-          name: "all"

--- a/sentences/en/fan_HassTurnOn.yaml
+++ b/sentences/en/fan_HassTurnOn.yaml
@@ -10,5 +10,4 @@ intents:
           - "activate [all] fan[s] [in] <area>"
         slots:
           domain: "fan"
-          name: "all"
         response: fans_area

--- a/sentences/en/light_HassLightSet.yaml
+++ b/sentences/en/light_HassLightSet.yaml
@@ -22,14 +22,10 @@ intents:
           - "[<numeric_value_set>] <area> brightness [to] <brightness>"
           - "[<numeric_value_set>] <area> [to] <brightness> brightness"
           - "[<numeric_value_set>] <area> [to] <brightness>"
-        slots:
-          name: "all"
         response: "brightness"
 
       - sentences:
           - "<numeric_value_set> <area> to <brightness>"
-        slots:
-          name: "all"
         response: "brightness"
 
       # Max/Min brightness
@@ -46,8 +42,6 @@ intents:
           - "[<numeric_value_set>] [the] brightness of <area> to [the] {brightness_level:brightness}"
           - "[<numeric_value_set>] <area> brightness to [the] {brightness_level:brightness}"
           - "[<numeric_value_set>] <area> [to] [the] {brightness_level:brightness} brightness"
-        slots:
-          name: "all"
         response: "brightness"
 
       # color
@@ -60,6 +54,4 @@ intents:
       - sentences:
           - "[<set>] [[the] color of] (<area> | [all] lights in <area> | [all] <area> lights) [to] {color}"
           - "[<set>] (<area> | [all] lights in <area> | [all] <area> lights) [color] [to] {color}"
-        slots:
-          name: "all"
         response: "color"

--- a/sentences/en/light_HassTurnOff.yaml
+++ b/sentences/en/light_HassTurnOff.yaml
@@ -25,5 +25,3 @@ intents:
         response: "light_all"
         slots:
           domain: "light"
-          area: "all"
-          name: "all"

--- a/sentences/en/lock_HassTurnOff.yaml
+++ b/sentences/en/lock_HassTurnOff.yaml
@@ -13,5 +13,4 @@ intents:
           - "unlock [all] <area> [locks|doors]"
         slots:
           domain: "lock"
-          name: "all"
         response: lock

--- a/sentences/en/lock_HassTurnOn.yaml
+++ b/sentences/en/lock_HassTurnOn.yaml
@@ -13,5 +13,4 @@ intents:
           - "lock [all] <area> [locks|doors]"
         slots:
           domain: "lock"
-          name: "all"
         response: lock

--- a/tests/en/fan_HassTurnOff.yaml
+++ b/tests/en/fan_HassTurnOff.yaml
@@ -17,7 +17,6 @@ tests:
       slots:
         area: Living Room
         domain: fan
-        name: all
     response: "Turned off fans"
 
   - sentences:
@@ -29,5 +28,3 @@ tests:
       name: HassTurnOff
       slots:
         domain: fan
-        area: all
-        name: all

--- a/tests/en/fan_HassTurnOn.yaml
+++ b/tests/en/fan_HassTurnOn.yaml
@@ -18,5 +18,4 @@ tests:
       slots:
         area: Kitchen
         domain: fan
-        name: all
     response: Turned on fans

--- a/tests/en/light_HassLightSet.yaml
+++ b/tests/en/light_HassLightSet.yaml
@@ -31,7 +31,6 @@ tests:
       slots:
         brightness: 50
         area: Bedroom
-        name: all
     response: "Brightness set"
 
   - sentences:
@@ -59,7 +58,6 @@ tests:
       slots:
         brightness: 100
         area: Bedroom
-        name: all
     response: "Brightness set"
 
   - sentences:
@@ -83,7 +81,6 @@ tests:
       slots:
         brightness: 1
         area: Bedroom
-        name: all
     response: "Brightness set"
 
   # color
@@ -112,5 +109,4 @@ tests:
       slots:
         color: red
         area: Bedroom
-        name: all
     response: "Color set"

--- a/tests/en/light_HassTurnOff.yaml
+++ b/tests/en/light_HassTurnOff.yaml
@@ -38,5 +38,3 @@ tests:
       name: HassTurnOff
       slots:
         domain: light
-        area: all
-        name: all

--- a/tests/en/lock_HassTurnOff.yaml
+++ b/tests/en/lock_HassTurnOff.yaml
@@ -19,5 +19,4 @@ tests:
       slots:
         area: Kitchen
         domain: lock
-        name: all
     response: Unlocked

--- a/tests/en/lock_HassTurnOn.yaml
+++ b/tests/en/lock_HassTurnOn.yaml
@@ -19,5 +19,4 @@ tests:
       slots:
         area: Kitchen
         domain: lock
-        name: all
     response: Locked


### PR DESCRIPTION
Some sentences hard-coded `name` and `area` slots with `"all"` values. This made the intents mismatch unless the user had entities and/or areas called `all`